### PR TITLE
Fixes and Updates to Interceptors

### DIFF
--- a/stats/condition_interceptor.go
+++ b/stats/condition_interceptor.go
@@ -33,6 +33,11 @@ func (s *ConditionStatsCreateInterceptor) After(resource interface{}) {
 
 		var err error
 
+		// We don't want to compute statistics for conditions we don't track
+		if !s.PgDataAccess.ConditionIsTracked(condition) {
+			return
+		}
+
 		if condition.Subject == nil {
 			log.Printf("ConditionStatsCreateInterceptor: Condition %s has no subject\n", condition.Id)
 			return

--- a/stats/condition_interceptor_test.go
+++ b/stats/condition_interceptor_test.go
@@ -51,6 +51,12 @@ func (s *ConditionInterceptorTestSuite) SetupSuite() {
 }
 
 func (s *ConditionInterceptorTestSuite) TearDownSuite() {
+	// zero out the stats for the next test
+	_, _ = s.db.Query("UPDATE synth_ma.synth_county_stats SET pop = 0, pop_male = 0, pop_female = 0, pop_sm = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_cousub_stats SET pop = 0, pop_male = 0, pop_female = 0, pop_sm = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_county_facts SET pop = 0, pop_male = 0, pop_female = 0, rate = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_cousub_facts SET pop = 0, pop_male = 0, pop_female = 0, rate = 0;")
+
 	// close the db connection after testing is finished
 	s.db.Close()
 

--- a/stats/patient_interceptor_test.go
+++ b/stats/patient_interceptor_test.go
@@ -38,6 +38,13 @@ func (s *PatientInterceptorTestSuite) SetupSuite() {
 }
 
 func (s *PatientInterceptorTestSuite) TearDownSuite() {
+
+	// zero out the stats for the next test
+	_, _ = s.db.Query("UPDATE synth_ma.synth_county_stats SET pop = 0, pop_male = 0, pop_female = 0, pop_sm = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_cousub_stats SET pop = 0, pop_male = 0, pop_female = 0, pop_sm = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_county_facts SET pop = 0, pop_male = 0, pop_female = 0, rate = 0;")
+	_, _ = s.db.Query("UPDATE synth_ma.synth_cousub_facts SET pop = 0, pop_male = 0, pop_female = 0, rate = 0;")
+
 	// close the db connection after testing is finished
 	s.db.Close()
 }


### PR DESCRIPTION
1. Added a check in the Condition interceptor that only runs the
   interceptor for conditions (diseases) we actually track, rather than
   any condition.
2. Added computation for disease “rate” in the fact tables. Added tests
   to validate this new feature.
3. Updated tests to cleanup the database after each test item (not sure
   if the tests are run in order or not, but good practice dictates that
   order should not matter).
