### PR TITLE
Added Read-Only Option

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 
+	"github.com/gin-gonic/gin"
 	"github.com/intervention-engine/fhir/server"
 )
 
@@ -13,6 +14,7 @@ func main() {
 	dbName := flag.String("dbname", "fhir", "Mongo database name")
 	idxConfigPath := flag.String("idxconfig", "config/indexes.conf", "Path to the indexes config file")
 	mongoHost := flag.String("mongohost", "localhost", "the hostname of the mongo database")
+	readOnly := flag.Bool("readonly", false, "Run the API in read-only mode (no creates, updates, or deletes allowed)")
 
 	flag.Parse()
 
@@ -37,5 +39,24 @@ func main() {
 		s.Engine.Use(server.RequestLoggerHandler)
 	}
 
+	if *readOnly {
+		s.Engine.Use(ReadOnlyHandler)
+	}
+
 	s.Run(config)
+}
+
+// ReadOnlyHandler makes the API read-only and responds to any requests that are not
+// GET, HEAD, or OPTIONS with a 403 Forbidden error.
+func ReadOnlyHandler(c *gin.Context) {
+
+	method := c.Request.Method
+	switch method {
+	// allowed methods:
+	case "GET", "HEAD", "OPTIONS":
+		return
+	// all other methods:
+	default:
+		c.AbortWithStatus(403)
+	}
 }


### PR DESCRIPTION
Added a ReadOnlyHandler that can be enabled with the -readonly flag. This responds with a 403 Forbidden error to any requests with methods that are not GET, HEAD, or OPTIONS.
