### PR TITLE
Added us-core search parameters

### DIFF
--- a/fixtures/patients.json
+++ b/fixtures/patients.json
@@ -1,0 +1,82 @@
+[
+    {
+        "resourceType": "Patient",
+        "id": "58a4904e97bba945de21eac8",
+        "name": [
+            {
+                "given": ["Lowell"],
+                "family": "Abbott"
+            }
+        ],
+        "gender": "male",
+        "birthDate": "1950-09-02",
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+                "valueCodeableConcept": {
+                    "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v3/Race",
+                        "code": "2106-3",
+                        "display": "White"
+                    }
+                    ],
+                    "text": "race"
+                }
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
+                "valueCodeableConcept": {
+                    "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v3/Ethnicity",
+                        "code": "2186-5",
+                        "display": "Nonhispanic"
+                    }
+                    ],
+                    "text": "ethnicity"
+                }
+            }
+        ]
+    },
+    {
+        "resourceType": "Patient",
+        "id": "58a4904e97bba945de21eac9",
+        "name": [
+            {
+                "given": ["Saul"],
+                "family": "French"
+            }
+        ],
+        "gender": "male",
+        "birthDate": "1974-10-06",
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+                "valueCodeableConcept": {
+                    "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v3/Race",
+                        "code": "2054-5",
+                        "display": "Black"
+                    }
+                    ],
+                    "text": "race"
+                }
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
+                "valueCodeableConcept": {
+                    "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v3/Ethnicity",
+                        "code": "2186-5",
+                        "display": "Nonhispanic"
+                    }
+                    ],
+                    "text": "ethnicity"
+                }
+            }
+        ]
+    }
+]

--- a/synthma/condition_param_test.go
+++ b/synthma/condition_param_test.go
@@ -69,7 +69,7 @@ func (suite *ConditionCodeParamSuite) TestConditionCodeBSONBuilder() {
 	require.NoError(err)
 
 	// Run the BSON builder
-	obtained, err := ConditionCodeBSONBuilder(param, search.NewMongoSearcher(server.Database))
+	obtained, err := ConditionCodeBSONBuilder(param, search.NewMongoSearcher(server.Database, false))
 	require.NoError(err)
 
 	// Check the BSON obtained

--- a/synthma/us_core_ext.go
+++ b/synthma/us_core_ext.go
@@ -1,0 +1,102 @@
+package synthma
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/intervention-engine/fhir/search"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// Custom search parameters for us-core FHIR extensions (race, ethnicity).
+func init() {
+	registry := search.GlobalRegistry()
+
+	// Register the us-core-race parameter.
+	fmt.Println("Registered 'race' search parameter on 'Patient'.")
+	registry.RegisterParameterInfo(USCoreRaceParamInfo)
+	registry.RegisterParameterParser(USCoreRaceParamInfo.Type, USCoreRaceParamParser)
+	search.GlobalMongoRegistry().RegisterBSONBuilder(USCoreRaceParamInfo.Type, USCoreRaceBSONBuilder)
+
+	// Register the us-core-ethnicity parameter.
+	fmt.Println("Registered 'ethnicity' search parameter on 'Patient'.")
+	registry.RegisterParameterInfo(USCoreEthnicityParamInfo)
+	registry.RegisterParameterParser(USCoreEthnicityParamInfo.Type, USCoreEthnicityParamParser)
+	search.GlobalMongoRegistry().RegisterBSONBuilder(USCoreEthnicityParamInfo.Type, USCoreEthnicityBSONBuilder)
+}
+
+// USCoreRaceParam represents the "us-core-race" search parameter. Patient's may be searched
+// by their race using a combination of system and code. This behaves exactly the same
+// as a standard TokenParam. See: http://hl7.org/fhir/2017jan/search.html#token
+type USCoreRaceParam struct {
+	search.TokenParam
+}
+
+var USCoreRaceParamInfo = search.SearchParamInfo{
+	Resource: "Patient",
+	Name:     "race",
+	Type:     "synthma.race",
+}
+
+// USCoreRaceParamParser parses the parameter and returns a USCoreRaceParam.
+var USCoreRaceParamParser = func(info search.SearchParamInfo, data search.SearchParamData) (search.SearchParam, error) {
+	return &USCoreRaceParam{
+		TokenParam: *search.ParseTokenParam(data.Value, info),
+	}, nil
+}
+
+// USCoreRaceBSONBuilder builds the Mongo BSON object corresponding to the query by Patient race.
+var USCoreRaceBSONBuilder = func(param search.SearchParam, searcher *search.MongoSearcher) (object bson.M, err error) {
+	p, ok := param.(*USCoreRaceParam)
+	if !ok {
+		return nil, errors.New("Expected a USCoreRaceParam")
+	}
+
+	system := "http://hl7.org/fhir/v3/Race"
+	if p.System != "" {
+		system = p.System
+	}
+
+	return bson.M{
+		"extension.us-core-race.coding.system": system,
+		"extension.us-core-race.coding.code":   p.Code,
+	}, nil
+}
+
+// USCoreEthnicityParam represents the "us-core-ethnicity" search parameter. Patient's may be searched
+// by their ethnicity using a combination of system and code. This behaves exactly the same
+// as a standard TokenParam. See: http://hl7.org/fhir/2017jan/search.html#token
+type USCoreEthnicityParam struct {
+	search.TokenParam
+}
+
+var USCoreEthnicityParamInfo = search.SearchParamInfo{
+	Resource: "Patient",
+	Name:     "ethnicity",
+	Type:     "synthma.ethnicity",
+}
+
+// USCoreEthnicityParamParser parses the parameter and returns a USCoreEthnicityParam.
+var USCoreEthnicityParamParser = func(info search.SearchParamInfo, data search.SearchParamData) (search.SearchParam, error) {
+	return &USCoreEthnicityParam{
+		TokenParam: *search.ParseTokenParam(data.Value, info),
+	}, nil
+}
+
+// USCoreEthnicityBSONBuilder builds the Mongo BSON object corresponding to the query by Patient ethnicity.
+var USCoreEthnicityBSONBuilder = func(param search.SearchParam, searcher *search.MongoSearcher) (object bson.M, err error) {
+	p, ok := param.(*USCoreEthnicityParam)
+	if !ok {
+		return nil, errors.New("Expected a USCoreEthnicityParam")
+	}
+
+	system := "http://hl7.org/fhir/v3/Ethnicity"
+	if p.System != "" {
+		system = p.System
+	}
+
+	return bson.M{
+		"extension.us-core-ethnicity.coding.system": system,
+		"extension.us-core-ethnicity.coding.code":   p.Code,
+	}, nil
+}

--- a/synthma/us_core_ext_test.go
+++ b/synthma/us_core_ext_test.go
@@ -1,0 +1,127 @@
+package synthma
+
+import (
+	"testing"
+
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/intervention-engine/fhir/search"
+	"github.com/intervention-engine/fhir/server"
+	"github.com/stretchr/testify/suite"
+	"github.com/synthetichealth/gofhir/testutil"
+)
+
+func TestUSCoreParamsSuite(t *testing.T) {
+	suite.Run(t, new(USCoreParamsSuite))
+}
+
+type USCoreParamsSuite struct {
+	// see: https://github.com/intervention-engine/ie/blob/master/testutil/MongoSuite.go for original source
+	testutil.MongoSuite
+}
+
+func (suite *USCoreParamsSuite) SetupTest() {
+	// Setup the database
+	server.Database = suite.DB()
+}
+
+func (suite *USCoreParamsSuite) TearDownTest() {
+	suite.TearDownDB()
+}
+
+func (suite *USCoreParamsSuite) TearDownSuite() {
+	suite.TearDownDBServer()
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreRaceParamParserCodeOnly() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	p, err := USCoreRaceParamParser(USCoreRaceParamInfo, search.SearchParamData{Value: "2106-3"})
+	require.NoError(err)
+	assert.IsType(new(USCoreRaceParam), p)
+	assert.Equal("2106-3", p.(*USCoreRaceParam).Code)
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreRaceParamParserSystemAndCode() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	p, err := USCoreRaceParamParser(USCoreRaceParamInfo, search.SearchParamData{Value: "http://hl7.org/fhir/v3/Race|2106-3"})
+	require.NoError(err)
+	assert.IsType(new(USCoreRaceParam), p)
+	assert.Equal("http://hl7.org/fhir/v3/Race", p.(*USCoreRaceParam).System)
+	assert.Equal("2106-3", p.(*USCoreRaceParam).Code)
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreRaceBSONBuilder() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	// Load some patients into the database
+	patients := make([]models.Patient, 2)
+	suite.InsertFixture("patients", "../fixtures/patients.json", &patients)
+
+	// Create the search parameter
+	// 2106-3 = White
+	param, err := USCoreRaceParamParser(USCoreRaceParamInfo, search.SearchParamData{Value: "2106-3"})
+	require.NoError(err)
+
+	// Run the BSON builder
+	obtained, err := USCoreRaceBSONBuilder(param, search.NewMongoSearcher(server.Database, false))
+	require.NoError(err)
+
+	// Check the BSON obtained
+	expected := bson.M{
+		"extension.us-core-race.coding.system": "http://hl7.org/fhir/v3/Race",
+		"extension.us-core-race.coding.code":   "2106-3",
+	}
+	assert.Equal(expected, obtained)
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreEthnicityParamParserCodeOnly() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	p, err := USCoreEthnicityParamParser(USCoreEthnicityParamInfo, search.SearchParamData{Value: "2186-5"})
+	require.NoError(err)
+	assert.IsType(new(USCoreEthnicityParam), p)
+	assert.Equal("2186-5", p.(*USCoreEthnicityParam).Code)
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreEthnicityParamParserSystemAndCode() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	p, err := USCoreEthnicityParamParser(USCoreEthnicityParamInfo, search.SearchParamData{Value: "http://hl7.org/fhir/v3/Ethnicity|2186-5"})
+	require.NoError(err)
+	assert.IsType(new(USCoreEthnicityParam), p)
+	assert.Equal("http://hl7.org/fhir/v3/Ethnicity", p.(*USCoreEthnicityParam).System)
+	assert.Equal("2186-5", p.(*USCoreEthnicityParam).Code)
+}
+
+func (suite *USCoreParamsSuite) TestUSCoreEthnicityBSONBuilder() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	// Load some patient into the database
+	patients := make([]models.Patient, 2)
+	suite.InsertFixture("patients", "../fixtures/patients.json", &patients)
+
+	// Create the search parameter
+	// 2186-5 = Nonhispanic
+	param, err := USCoreEthnicityParamParser(USCoreEthnicityParamInfo, search.SearchParamData{Value: "2186-5"})
+	require.NoError(err)
+
+	// Run the BSON builder
+	obtained, err := USCoreEthnicityBSONBuilder(param, search.NewMongoSearcher(server.Database, false))
+	require.NoError(err)
+
+	// Check the BSON obtained
+	expected := bson.M{
+		"extension.us-core-ethnicity.coding.system": "http://hl7.org/fhir/v3/Ethnicity",
+		"extension.us-core-ethnicity.coding.code":   "2186-5",
+	}
+	assert.Equal(expected, obtained)
+}


### PR DESCRIPTION
Added token search parameters for us-core-race and us-core-ethnicity, allowing both extensions to be searched by system and/or code.

Search by race (e.g. "White"):
```
GET /Patient?race=2106-3
GET /Patient?race=http://hl7.org/fhir/v3/Race|2106-3
```

Search by ethnicity (e.g. "Nonhispanic"):
```
GET /Patient?ethnicity=2186-5
GET /Patient?ethnicity=http://hl7.org/fhir/v3/Ethnicity|2186-5
```

At scale, the following indexes will also be needed:

```
patients.extension.us-core-race.coding.code_1
patients.extension.us-core-ethnicity.coding.code_1
```