### PR TITLE
Added additional, custom indexes for our large collections

### DIFF
--- a/config/indexes.conf
+++ b/config/indexes.conf
@@ -48,7 +48,9 @@ allergyintolerances.(patient.referenceid_1, patient.type_1)
 allergyintolerances.(recorder.referenceid_1, recorder.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+allergyintolerances.category_1
+allergyintolerances.(code.coding.code_1, code.coding.system_1)
+allergyintolerances,assertedDate.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: appointmentresponses
@@ -139,7 +141,11 @@ careplans.(relatedPlan.plan.referenceid_1, relatedPlan.plan.type_1)
 careplans.(subject.referenceid_1, subject.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+careplans.status_1
+careplans.(category.coding.code_1, category.coding.system_1)
+careplans.period.start.time_1
+careplans.period.end.time_1
+careplans.(activity.detail.code.coding.code_1, activity.detail.code.coding.system_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: careteams
@@ -266,7 +272,9 @@ conditions.(context.referenceid_1, context.type_1)
 conditions.(subject.referenceid_1, subject.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+conditions.clinicalStatus_1
+conditions.(code.coding.code_1, code.coding.system_1)
+conditions.onsetDateTime.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: consents
@@ -400,7 +408,10 @@ diagnosticreports.(specimen.referenceid_1, specimen.type_1)
 diagnosticreports.(subject.referenceid_1, subject.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+diagnosticreports.status_1
+diagnosticreports.(code.coding.code_1, code.coding.system_1)
+diagnosticreports.effectiveDateTime.time_1
+diagnosticreports.issued.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: diagnosticrequests
@@ -484,7 +495,11 @@ encounters.(patient.referenceid_1, patient.type_1)
 encounters.(serviceProvider.referenceid_1, serviceProvider.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+encounters.status_1
+encounters.class.code_1
+encounters.(type.coding.code_1, type.coding.system_1)
+encounters.period.start.time_1
+encounters.period.end.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: endpoints
@@ -653,7 +668,9 @@ immunizations.(reaction.detail.referenceid_1, reaction.detail.type_1)
 immunizations.(requester.referenceid_1, requester.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+immunizations.status_1
+immunizations.date.time_1
+immunizations.(vaccineCode.coding.code_1, vaccineCode.coding.system_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: implementationguides
@@ -774,7 +791,9 @@ medicationrequests.(patient.referenceid_1, patient.type_1)
 medicationrequests.(requester.referenceid_1, requester.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+medicationrequests.(medicationCodeableConcept.coding.code_1, medicationCodeableConcept.coding.system_1)
+medicationrequests.dateWritten.time_1
+medicationrequests.status_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: medications
@@ -853,7 +872,10 @@ observations.(specimen.referenceid_1, specimen.type_1)
 observations.(subject.referenceid_1, subject.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+observations.status_1
+observations.(code.coding.code_1, code.coding.system_1)
+observations.effectiveDateTime.time_1
+observations.(valueQuantity.value_1, valueQuantity.code_1, valueQuantity.unit_1, valueQuantity.system_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: operationdefinitions
@@ -893,7 +915,17 @@ patients.(link.other.referenceid_1, link.other.type_1)
 patients.(managingOrganization.referenceid_1, managingOrganization.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+patients.(extension.us-core-race.coding.code_1, extension.us-core-race.coding.system_1)
+patients.(extension.us-core-ethnicity.coding.code_1, extension.us-core-ethnicity.coding.system_1)
+patients.name.family_1
+patients.name.given_1
+patients.birthDate.time_1
+patients.address.line_1
+patients.address.city_1
+patients.address.postalCode_1
+patients.(maritalStatus.coding.code_1, maritalStatus.coding.system_1)
+patients.gender_1
+patients.deceasedDateTime.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: paymentnotices
@@ -983,7 +1015,9 @@ procedures.(performer.actor.referenceid_1, performer.actor.type_1)
 procedures.(subject.referenceid_1, subject.type_1)
 
 # Optional Indexes:
-# You can add additional indexes here if needed
+procedures.status_1
+procedures.(code.coding.code_1, code.coding.system_1)
+procedures.performedDateTime.time_1
 
 # -------------------------------------------------------------------------------------------------
 # Collection: processrequests

--- a/config/indexes.conf
+++ b/config/indexes.conf
@@ -146,6 +146,8 @@ careplans.(category.coding.code_1, category.coding.system_1)
 careplans.period.start.time_1
 careplans.period.end.time_1
 careplans.(activity.detail.code.coding.code_1, activity.detail.code.coding.system_1)
+careplans.(activity.detail.reasonCode.coding.code_1, activity.detail.reasonCode.coding.system_1)
+careplans.(activity.detail.reasonReference.referenceid_1, activity.detail.reasonReference.type_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: careteams
@@ -500,6 +502,7 @@ encounters.class.code_1
 encounters.(type.coding.code_1, type.coding.system_1)
 encounters.period.start.time_1
 encounters.period.end.time_1
+encounters.(reason.coding.code_1, reason.coding.system_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: endpoints
@@ -794,6 +797,8 @@ medicationrequests.(requester.referenceid_1, requester.type_1)
 medicationrequests.(medicationCodeableConcept.coding.code_1, medicationCodeableConcept.coding.system_1)
 medicationrequests.dateWritten.time_1
 medicationrequests.status_1
+medicationrequests.(reasonCode.coding.code_1, reasonCode.coding.system_1)
+medicationrequests.(reasonReference.referenceid_1, reasonReference.type_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: medications
@@ -1018,6 +1023,8 @@ procedures.(subject.referenceid_1, subject.type_1)
 procedures.status_1
 procedures.(code.coding.code_1, code.coding.system_1)
 procedures.performedDateTime.time_1
+procedures.(reasonCode.coding.code_1, reasonCode.coding.system_1)
+procedures.(reasonReference.referenceid_1, reasonReference.type_1)
 
 # -------------------------------------------------------------------------------------------------
 # Collection: processrequests


### PR DESCRIPTION
I added indexes for all non-empty, searchable fields in the following resources:

* AllergyIntolerances
* CarePlans
* Conditions
* DiagnosticReports
* Encounters
* Immunizations
* MedicationRequests
* Observations
* Patients
* Procedures

For all code fields I added a compound index of the form `(coding.code_1, coding.system_1)`. This allows the same index to be used for searches _only_ by code, or searches including _both_ code and system.